### PR TITLE
restructure repo for milestone 2

### DIFF
--- a/audio_consumer/README.md
+++ b/audio_consumer/README.md
@@ -1,0 +1,58 @@
+# Audio Consumer
+
+This directory contains a kafka consumer python script that consumes raw audio data from a Kafka topic and saves it as a WAV file.
+
+## Configuration
+
+The configuration for the consumer is stored in a `consumer.properties` file. Below is an example configuration:
+
+```properties
+[consumer]
+bootstrap.servers=localhost:9092
+topic=raw_audio
+sample.rate=44100
+channels=2
+chunk.size=1024
+output.filename=raw_audio.wav
+idle.timeout=5
+```
+
+## Usage
+
+1. Ensure you have a Kafka server running and accessible at the address specified in the `consumer.properties` file.
+2. Install the required Python packages:
+    ```sh
+    pip install confluent_kafka sounddevice configparser
+    ```
+3. Run the audio consumer script:
+    ```sh
+    python3 consumer.py
+    ```
+
+
+## Files
+
+- `consumer.properties`: Configuration file for the Kafka consumer.
+- `consumer.py`: Main script to consume audio data from Kafka and save it as a WAV file.
+
+## How It Works
+
+- The script reads configuration from `consumer.properties`.
+- It checks if the Kafka server is available.
+- It initializes a Kafka consumer.
+- It consumes audio data from the specified Kafka topic.
+- It saves the consumed audio data as a WAV file.
+- The consumer will stop after a specified idle timeout if no messages are received.
+
+## Note
+
+- The consumer will stop after a specified idle timeout if no messages are received.
+- The consumer will save the audio data as a WAV file with the specified filename.
+- The consumer will overwrite the existing file if it already exists.
+
+
+## Dependencies
+
+- `confluent_kafka`
+- `sounddevice`
+- `configparser`

--- a/audio_consumer/consumer.properties
+++ b/audio_consumer/consumer.properties
@@ -1,0 +1,8 @@
+[consumer]
+bootstrap.servers=localhost:9092
+topic=raw_audio
+sample.rate=44100
+channels=2
+chunk.size=1024
+output.filename=raw_audio.wav
+idle.timeout=5

--- a/audio_consumer/consumer.py
+++ b/audio_consumer/consumer.py
@@ -1,0 +1,123 @@
+from confluent_kafka import Consumer, KafkaError
+import sounddevice as sd
+import wave
+import time
+import socket
+import threading
+import sys
+import configparser
+
+config = configparser.ConfigParser()
+config.read("./consumer.properties")
+
+KAFKA_SERVER = config.get("consumer", "bootstrap.servers")
+KAFKA_TOPIC = config.get("consumer", "topic")
+OUTPUT_FILENAME = config.get("consumer", "output.filename")
+SAMPLE_RATE = config.getint("consumer", "sample.rate")
+CHANNELS = config.getint("consumer", "channels")
+IDLE_TIMEOUT = config.getint("consumer", "idle.timeout")
+
+
+def spinner():
+    spinner_frames = ["|", "/", "-", "\\"]
+    idx = 0
+    while True:
+        sys.stdout.write(
+            "\r" + spinner_frames[idx % len(spinner_frames)] + " Consuming audio data...")
+        sys.stdout.flush()
+        idx += 1
+        time.sleep(0.1)
+
+
+def check_kafka_server(server):
+    host, port = server.split(":")
+    try:
+        socket.create_connection((host, int(port)), timeout=5)
+        return True
+    except (socket.timeout, ConnectionRefusedError, socket.gaierror):
+        return False
+
+
+# Check if Kafka server is available
+if not check_kafka_server(KAFKA_SERVER):
+    print(
+        f"Kafka server at {KAFKA_SERVER} is not available. Please check:\n 1. Kafka server is running\n 2. Kafka server address is correct\nTry again after resolving issues."
+    )
+    exit(1)
+else:
+    print(f"Kafka server at {KAFKA_SERVER} up and running")
+
+
+def consume_audio(
+    topic=KAFKA_TOPIC,
+    kafka_server=KAFKA_SERVER,
+    output_filename=OUTPUT_FILENAME,
+    sample_rate=SAMPLE_RATE,
+    channels=CHANNELS,
+    idle_timeout=IDLE_TIMEOUT,
+):
+    consumer = Consumer(
+        {
+            "bootstrap.servers": kafka_server,
+            "group.id": "raw_audio_consumer_group",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": True,  # Auto commit offsets (for now)
+        }
+    )
+
+    try:
+        consumer.subscribe([topic])
+    except Exception as e:
+        print(f"An error occurred while subscribing to the topic {topic}: {e}")
+        exit(1)
+
+    # Open the WAV file to write the received audio data
+    with wave.open(output_filename, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        last_message_time = time.time()
+
+        print("Press Ctrl+C to stop consuming audio data")
+
+        spinner_thread = threading.Thread(target=spinner)
+        spinner_thread.daemon = True
+        spinner_thread.start()
+
+        try:
+            while True:
+                if time.time() - last_message_time > idle_timeout:
+                    print(
+                        f"\nNo messages received for {idle_timeout} seconds. Closing consumer"
+                    )
+                    break
+
+                msg = consumer.poll(1.0)
+
+                if msg is None:
+                    continue
+                if msg.error():
+                    if msg.error().code() == KafkaError._PARTITION_EOF:
+                        print("\nKafka error: end of partition")
+                    elif msg.error().code() == KafkaError.UNKNOWN_TOPIC_OR_PART:
+                        print("\nKafka error: unknown topic or partition. Exiting.")
+                        exit(1)
+                    else:
+                        print("\nKafka error: ", msg.error().str())
+                        exit(1)
+                    continue
+
+                last_message_time = time.time()
+                audio_chunk = msg.value()
+                wf.writeframes(audio_chunk)
+
+        except KeyboardInterrupt:
+            print("\nInterrupt raised. Closing consumer...")
+        finally:
+            consumer.close()
+
+    print(f"Recording received and saved to: {output_filename}")
+
+
+if __name__ == "__main__":
+    consume_audio()


### PR DESCRIPTION
Changed repo layout to:
├── audio_producer       # Contains all code related to producing audio data to Kafka
├── audio_processor      # Contains code for processing audio data (so far librosa pitch shifting)
└── audio_consumer       # Contains code for consuming audio data from Kafka (playing real-time to be made later)

Created individual README.md files for each directory and updated main README.md.